### PR TITLE
Fix ParentJob missing error

### DIFF
--- a/PathTurnScripts/PathTurnFace.py
+++ b/PathTurnScripts/PathTurnFace.py
@@ -86,9 +86,9 @@ def SetupProperties():
     return setup
 
 
-def Create(name, obj=None):
+def Create(name, obj=None, parentJob=None):
     '''Create(name) ... Creates and returns a TurnFace operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    obj.Proxy = ObjectTurnFace(obj, name)
+    obj.Proxy = ObjectTurnFace(obj, name, parentJob)
     return obj

--- a/PathTurnScripts/PathTurnPartoff.py
+++ b/PathTurnScripts/PathTurnPartoff.py
@@ -81,9 +81,9 @@ def SetupProperties():
     return setup
 
 
-def Create(name, obj=None):
+def Create(name, obj=None, parentJob=None):
     '''Create(name) ... Creates and returns a TurnPart operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    obj.Proxy = ObjectTurnPart(obj, name)
+    obj.Proxy = ObjectTurnPart(obj, name, parentJob)
     return obj

--- a/PathTurnScripts/PathTurnProfile.py
+++ b/PathTurnScripts/PathTurnProfile.py
@@ -82,9 +82,9 @@ def SetupProperties():
     return setup
 
 
-def Create(name, obj=None):
+def Create(name, obj=None, parentJob=None):
     '''Create(name) ... Creates and returns a TurnProfile operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    obj.Proxy = ObjectTurnProfile(obj, name)
+    obj.Proxy = ObjectTurnProfile(obj, name, parentJob)
     return obj

--- a/PathTurnScripts/PathTurnRough.py
+++ b/PathTurnScripts/PathTurnRough.py
@@ -82,9 +82,9 @@ def SetupProperties():
     return setup
 
 
-def Create(name, obj=None):
+def Create(name, obj=None, parentJob=None):
     '''Create(name) ... Creates and returns a TurnRough operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    obj.Proxy = ObjectTurnRough(obj, name)
+    obj.Proxy = ObjectTurnRough(obj, name, parentJob)
     return obj


### PR DESCRIPTION
![image](https://github.com/dubstar-04/FreeCAD_Turning_Addon/assets/46846964/7f2c4e20-aa2d-4f6b-bb2c-5837a9834383)

There is an error 'Create() got an unexpected keyword argument 'parentJob' on Turn Face and Profile.
Compare to FreeCAD's code, there are differences on path codes. I add a parameter 'ParentJob' on Create function (in path codes).

(this module's code)
![image](https://github.com/dubstar-04/FreeCAD_Turning_Addon/assets/46846964/9ae65fae-7775-4276-81ec-7204ebcfa713)

(original code)
![image](https://github.com/dubstar-04/FreeCAD_Turning_Addon/assets/46846964/04c54127-3d1c-4b2c-815f-a12a7bc1904c)

Tested it on 0.20.2 and 0.19.